### PR TITLE
Force Travis to build on Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+dist: xenial
 
 language: node_js
 node_js:


### PR DESCRIPTION
Travis has [discontinued Trusty support](https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures) but the transition is slow.

This forces builds on [Xenial](https://docs.travis-ci.com/user/reference/xenial/)