### PR TITLE
Prefer border-image over background-image

### DIFF
--- a/stylesheets/screen.scss
+++ b/stylesheets/screen.scss
@@ -50,21 +50,22 @@ h3 {
     max-height: 400px;
     display: block;
     overflow: hidden;
-    background: #fff url(../images/map.jpg) top left no-repeat;
+    border-top: 350px solid transparent;
+    border-image: url(../images/map.jpg) 88% 0 0 0; // border is 350px high which is 88% of total height
+    background-color: #fff;
     margin: $header-margin 0 0 auto;
 
     @media
     (-webkit-min-device-pixel-ratio: 2),
     (min-resolution: 192dpi) {
       /* Retina-specific stuff here */
-      background: #fff url(../images/map@2x.jpg) top left no-repeat;
-      background-size: 400px 400px;
+      border-image: url(../images/map@2x.jpg) 88% 0 0 0;
     }
     @media (max-width: 992px) {
       /* align right when md column collapses */
       margin: $header-margin 0 0 0;
     }
-    padding: 410px 0px 10px 0px;
+    padding: 10px 0px 10px 0px;
     text-align: center;
     border-radius: 5px;
     box-shadow: 3px 3px 5px 6px #ccc;


### PR DESCRIPTION
Cropping the `background-image` at the right position proved difficult. Even with multiple backgrounds, I cannot get it postioned correctly. Multiple backgrounds are layered, and
only the final layer can contain a background-color (h/t https://stackoverflow.com/a/5852324/473467).

Add to the fact that the `background-color` is painted below all other layers (https://www.w3.org/TR/css-backgrounds-3/#layering), this will never work.

But the spec pointed me to the `border-image` properties, so I replaced the padding with a border + image.

Now it works!