### PR TITLE
Fix left margin in Berlin

### DIFF
--- a/stylesheets/berlin.scss
+++ b/stylesheets/berlin.scss
@@ -35,6 +35,6 @@ body > p:not(.img) {
   @extend %left-margin;
 }
 
-h2 {
+body > h2 {
   @extend %left-margin;
 }


### PR DESCRIPTION
With just `h2`, the rule is not specific enough to override the margin-left: -15px introduced in f9dc07760e.

# Before

<img width="589" alt="before" src="https://user-images.githubusercontent.com/11964/60916421-9166cd00-a28e-11e9-9b94-c204209d896b.png">

# After

<img width="589" alt="after" src="https://user-images.githubusercontent.com/11964/60916432-9a579e80-a28e-11e9-8d77-f78bbd31c08b.png">
