### PR TITLE
Improve dev experience for editing content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: website/index.html
 ##########################################
 # Check installation of required software
 ##########################################
-check: check-node check-npm check-pandoc
+check: check-fswatch check-node check-npm check-pandoc
 
 RED=\033[0;31m
 GREEN=\033[0;32m
@@ -41,16 +41,13 @@ website/data/berlin/%.json:
 	mkdir -p website/data/berlin
 	wget --directory-prefix=website/data/berlin --compression=auto https://www.familienradwege.de/data/berlin/$(notdir $@)
 
-PORT = 1234
-
 ###################################
 # Convenience tools for developing
 ###################################
 
-server:
-	ruby -run -e httpd website/ -p $(PORT) || php -S localhost:$(PORT)
+PORT ?= 1234
 
-watch:
-	npx parcel watch $(addprefix html/,$(HTML)) --out-dir website
+start-dev-server:
+	PORT=$(PORT) FILES="$(addprefix html/,$(HTML))" npx nf start
 
 ###################################

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HTML = index.html berlin/index.html daten/index.html
 
 # always re-build website
-.PHONY: website/index.html start-dev-server screenshots
+.PHONY: website/index.html start-dev-server screenshots html/index/index.html
 
 all: install local build
 
@@ -32,6 +32,9 @@ screenshots:
 
 website/index.html: $(addprefix html/,$(HTML))
 	npx parcel build $^ --out-dir website --no-source-maps
+
+# This phony target is just an alias
+html/index/index.html: html/index.html
 
 html/%.html html/%/index.html: pages/_navigation.md pages/%.md pages/_footer.md
 	mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ website/data/berlin/%.json:
 	mkdir -p website/data/berlin
 	wget --directory-prefix=website/data/berlin --compression=auto https://www.familienradwege.de/data/berlin/$(notdir $@)
 
+clean:
+	rm -rf .cache
+
 ###################################
 # Convenience tools for developing
 ###################################

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HTML = index.html berlin/index.html daten/index.html
 
 # always re-build website
-.PHONY: website/index.html server watch screenshots
+.PHONY: website/index.html start-dev-server screenshots
 
 all: install local build
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 HTML = index.html berlin/index.html daten/index.html
 
 # always re-build website
-.PHONY: website/index.html start-dev-server screenshots html/index/index.html
+.PHONY: website/index.html start-dev-server screenshots
 
 all: install local build
 
@@ -33,12 +33,12 @@ screenshots:
 website/index.html: $(addprefix html/,$(HTML))
 	npx parcel build $^ --out-dir website --no-source-maps
 
-# This phony target is just an alias
-html/index/index.html: html/index.html
-
-html/%.html html/%/index.html: pages/_navigation.md pages/%.md pages/_footer.md
+html/%/index.html: pages/_navigation.md pages/%.md pages/_footer.md
 	mkdir -p $(dir $@)
 	pandoc --standalone -f markdown-implicit_figures -t html5 $^ > $@
+
+html/index.html: html/index/index.html
+	cp $< $@
 
 website/data/berlin/%.json:
 	mkdir -p website/data/berlin

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 server: ruby -run -e httpd website/ -p $PORT || php -S localhost:$PORT
-markdown: fswatch -0 pages | xargs -0 -I {} basename {} .md | xargs -I % make html/%.html html/%/index.html
+markdown: fswatch -0 pages | xargs -0 -I {} basename {} .md | xargs -I % make html/%/index.html
 parcel: npx parcel watch $FILES --out-dir website

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 server: ruby -run -e httpd website/ -p $PORT || php -S localhost:$PORT
-markdown: fswatch -0 pages | xargs -0 -I {} basename {} .md | xargs -I % make html/%/index.html
+markdown: fswatch -0 pages | xargs -0 -I {} basename {} .md | xargs -I % make html/%/index.html html/index.html
 parcel: npx parcel watch $FILES --out-dir website

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+server: ruby -run -e httpd website/ -p $PORT || php -S localhost:$PORT
+markdown: fswatch -0 pages | xargs -0 -I {} basename {} .md | xargs -I % make html/%.html html/%/index.html
+parcel: npx parcel watch $FILES --out-dir website

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Run the following, every line should have a check mark:
 
 ```bash
 $ make check
+✔ fswatch
 ✔ node
 ✔ npm
 ✔ pandoc
@@ -52,23 +53,39 @@ This will do the following:
 2. Download map data
 3. Create all HTML and all referenced files (images, CSS) and place them into the sub-directory `website/`
 
-To view the website, run:
+### Development server
+
+There is a development server which will automatically rebuild your app as you
+change files and supports hot module replacement for fast development.
+
+This server requires [`fswatch`](https://github.com/emcrisostomo/fswatch).
+To run the dev server, run:
 
 ```
-$ make server
+$ make start-dev-server
 ```
 
 and point your browser to http://localhost:1234/.
-You can adjust the port using `make server PORT=4321`.
+You can adjust the port using `make start-dev-server PORT=xyz`.
 
-### Re-build when files change
+<details>
+<summary>How is this dev server working?</summary>
 
-If you leave `make server` running in a terminal and run watch mode in another,
-you can change files and see the changes immediately in your browser:
+[Parcel ships with development server](https://parceljs.org/getting_started.html)
+but since you don't edit HTML files directly in this project, that's not enough.
+So to make this easy to work with, we need 3 parts:
 
-```
-$ make watch
-```
+1. `fswatch` watches Markdown files and re-builds HTML if necessary.
+2. Parcel watches HTML files and its asset dependencies (Javascript, CSS),
+   re-builds the website if necessary and ensures your browser is updated.
+3. The server that serves the application to the browser. Parcel could do this
+   itself but it does not recognize the permalinks this project is using.
+
+These three parts are orchestrated by the [`Procfile`](Procfile) and
+[`node-foreman`](https://github.com/strongloop/node-foreman) which is started
+when you run `make start-dev-server`.
+
+</details>
 
 ### Creating new pages
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ when you run `make start-dev-server`.
 
 </details>
 
+When you have any problems with files not being updated, as a first step,
+stop the dev server and run:
+
+```
+make clean
+```
+
+Doing so removes Parcel's cache so you can start over with a clean state.
+This is a safe command – it does not touch any of the files you edited.
+
 ### Creating new pages
 
 You can find all content under [`pages`](pages).

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can adjust the port using `make start-dev-server PORT=xyz`.
 <details>
 <summary>How is this dev server working?</summary>
 
-[Parcel ships with development server](https://parceljs.org/getting_started.html)
+[Parcel ships with a development server](https://parceljs.org/getting_started.html)
 but since you don't edit HTML files directly in this project, that's not enough.
 So to make this easy to work with, we need 3 parts:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2748,6 +2748,12 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eventemitter3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+      "dev": true
+    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -2981,6 +2987,26 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2990,6 +3016,18 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "foreman": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/foreman/-/foreman-3.0.1.tgz",
+      "integrity": "sha512-ek/qoM0vVKpxzkBUQN9k4Fs7l0XsHv4bqxuEW6oqIS4s0ouYKsQ19YjBzUJKTFRumFiSpUv7jySkrI6lfbhjlw==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.15.1",
+        "http-proxy": "^1.17.0",
+        "mustache": "^2.2.1",
+        "shell-quote": "^1.6.1"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -3868,6 +3906,17 @@
         }
       }
     },
+    "http-proxy": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -4685,6 +4734,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "dev": true
     },
     "nan": {
       "version": "2.14.0",
@@ -6177,6 +6232,12 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -6446,6 +6507,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
     },
     "sigmund": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "file-saver": "^2.0.2",
+    "foreman": "^3.0.1",
     "node-sass": "^4.12.0"
   }
 }


### PR DESCRIPTION
This introduces `make start-dev-server` which spins up 3 processes:

1. A file watcher for anything markdown changes in `pages/` so they're compiled to HTML
2. [Parcel's watcher](https://parceljs.org/getting_started.html) that builds the application once and then watches for any changes to HTML, Javascript or CSS
3. A web server that serves the application because Parcel's built-in server does not server `berlin/index.html` when `/berlin` is requested (see https://github.com/parcel-bundler/parcel/issues/1315)

This introduces a new dependency, [`fswatch`](https://github.com/emcrisostomo/fswatch). It needs to be installed on the system just like Node or Pandoc. (Maybe there's a Node port for it, that would make things even smoother…)