### PR TITLE
npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4201,9 +4201,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "lcid": {
       "version": "1.0.0",
@@ -4464,9 +4464,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -4488,18 +4488,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
     },
     "ms": {


### PR DESCRIPTION
Still, not all versions of minimist are updated:

```
$ npm ls minimist
├─┬ node-sass@4.13.1
│ ├─┬ meow@3.7.0
│ │ └── minimist@1.2.5
│ └─┬ mkdirp@0.5.5
│   └── minimist@1.2.5  deduped
└─┬ parcel-bundler@1.12.4
  ├─┬ @babel/core@7.7.7
  │ └─┬ json5@2.1.1
  │   └── minimist@1.2.5  deduped
  ├─┬ @parcel/logger@1.11.1
  │ └─┬ grapheme-breaker@0.3.2
  │   └─┬ brfs@1.6.1
  │     └─┬ quote-stream@1.0.2
  │       └── minimist@1.2.5  deduped
  ├─┬ @parcel/watcher@1.12.1
  │ └─┬ chokidar@2.1.8
  │   └─┬ fsevents@1.2.11
  │     └─┬ node-pre-gyp@0.14.0
  │       ├─┬ mkdirp@0.5.1
  │       │ └── minimist@0.0.8
  │       └─┬ rc@1.2.8
  │         └── minimist@1.2.0
  └─┬ json5@1.0.1
    └── minimist@1.2.5  deduped
```