### PR TITLE
Add Github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: build-page
 
 on: [push]
 
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -13,8 +16,6 @@ jobs:
         node-version: '12'
     - name: Install pandoc
       run: brew install pandoc
-      env:
-        HOMEBREW_NO_AUTO_UPDATE: 1
     - uses: actions/cache@v2
       with:
         path: ~/.npm
@@ -44,9 +45,13 @@ jobs:
       with:
         name: website
         path: website
+    - name: Install libxml2
+      run: brew install libxml2
     - name: Debug gem env
       run: gem env
     - name: Install html-proofer
-      run: gem install html-proofer
+      env:
+        NOKOGIRI_USE_SYSTEM_LIBRARIES: true
+      run: gem install pkg-config:'~> 1.4' html-proofer
     - name: Check website
       run: htmlproofer --empty-alt-ignore website

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: website
+        path: website
     - name: Debug gem env
       run: gem env
     - name: Install html-proofer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build-page
 
-on: [push]
+on: [push, pull_request]
 
 env:
   HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ jobs:
           ${{ runner.os }}-node-
     - name: Install dependencies
       run: npm ci
+    - name: Debug gem env
+      run: gem env
     - name: Install html-proofer
-      run: gem install html-proofer
+      run: gem install html-proofer --user-install
     - name: Build website and proof it
       run: make build proof

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,13 +45,11 @@ jobs:
       with:
         name: website
         path: website
-    - name: Install libxml2
-      run: brew install libxml2
-    - name: Debug gem env
-      run: gem env
+    - name: Nokogiri dependencies
+      run: sudo apt-get install --no-upgrade libxml2-dev libxslt-dev
     - name: Install html-proofer
       env:
         NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-      run: gem install pkg-config:'~> 1.4' html-proofer
+      run: gem install html-proofer
     - name: Check website
       run: htmlproofer --empty-alt-ignore website

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       run: gem env
     - name: Install html-proofer
       run: gem install html-proofer --user-install
-    - name: Inspect path
-      run: ls -la ~/.gem/ruby/2.7.0
+    - name: Add PATH
+      run: echo "::add-path::~/.gem/ruby/2.7.0/bin"
     - name: Build website and proof it
       run: make build proof

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
         node-version: '12'
     - name: Install pandoc
       run: brew install pandoc
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
     - uses: actions/cache@v2
       with:
         path: ~/.npm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Debug gem env
       run: gem env
     - name: Inspect path
-      run: tree ~/.gem/ruby/2.7.0
+      run: ls -la ~/.gem/ruby/2.7.0
     - name: Install html-proofer
       run: gem install html-proofer --user-install
     - name: Build website and proof it

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: build-page
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - name: Install pandoc
+      run: brew install pandoc
+    - name: Check pandoc version
+      run: pandoc --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,5 +13,15 @@ jobs:
         node-version: '12'
     - name: Install pandoc
       run: brew install pandoc
-    - name: Check pandoc version
-      run: pandoc --version
+    - uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+    - name: Install dependencies
+      run: npm ci
+    - name: Install html-proofer
+      run: gem install html-proofer
+    - name: Build website and proof it
+      run: make build proof

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: 2.7
     - name: Download website artifact from build job
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,29 @@ jobs:
           ${{ runner.os }}-node-
     - name: Install dependencies
       run: npm ci
+    - name: Build website
+      run: make build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: website
+        path: website
+
+  check:
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+    - name: Download website artifact from build job
+      uses: actions/download-artifact@v2
+      with:
+        name: website
     - name: Debug gem env
       run: gem env
     - name: Install html-proofer
-      run: gem install html-proofer --user-install
-    - name: Add PATH
-      run: echo "::add-path::~/.gem/ruby/2.7.0/bin"
-    - name: Build website and proof it
-      run: make build proof
+      run: gem install html-proofer
+    - name: Check website
+      run: make proof

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
     - name: Install html-proofer
       run: gem install html-proofer
     - name: Check website
-      run: make proof
+      run: htmlproofer --empty-alt-ignore website

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
       run: npm ci
     - name: Debug gem env
       run: gem env
-    - name: Inspect path
-      run: ls -la ~/.gem/ruby/2.7.0
     - name: Install html-proofer
       run: gem install html-proofer --user-install
+    - name: Inspect path
+      run: ls -la ~/.gem/ruby/2.7.0
     - name: Build website and proof it
       run: make build proof

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
       run: npm ci
     - name: Debug gem env
       run: gem env
+    - name: Inspect path
+      run: tree ~/.gem/ruby/2.7.0
     - name: Install html-proofer
       run: gem install html-proofer --user-install
     - name: Build website and proof it


### PR DESCRIPTION
This runs the build-and-check routine in Github, in addition to Travis CI.

# Things I learned

1. ⏱️ It's much slower than Travis ([~3 minutes](https://github.com/awendt/familienradwege-website/actions/runs/134457666) vs. [1.5 minutes](https://travis-ci.org/github/awendt/familienradwege-website/builds/698032908)) – installing `html-proofer` + `nokogiri` takes a whopping 70s (Travis: 20s)
2. 🏚️ `actions/setup-ruby` is currently unusable, `ruby/setup-ruby` is prefered
3. 🎉 [actions/upload-artifact](https://github.com/actions/upload-artifact) is awesome for [persisting data between jobs](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts) and will be useful for https://github.com/awendt/familienradwege/pull/26
4. 🧑‍🤝‍🧑 The overhead added by running a second job in a workflow is minor, and it helps to keep jobs focused.
5. 🍻 `brew install` is slow by default on Github Actions
6. 🔍 Still missing: Upload to S3 – but this should be easy now