### PR TITLE
GitHub workflow uses htmlproofer in docker container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
         name: website
         path: website
     - name: Check website
-      run: /usr/gem/bin/htmlproofer --empty-alt-ignore
+      run: /usr/gem/bin/htmlproofer --empty-alt-ignore website

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,7 @@ jobs:
   check:
     needs: build
     runs-on: ubuntu-20.04
-    container:
-      image: jekyll/builder:latest
-      volumes:
-        - website:/srv/jekyll
+    container: jekyll/builder:latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
     - name: Download website artifact from build job
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ jobs:
   check:
     needs: build
     runs-on: ubuntu-20.04
+    container:
+      image: jekyll/builder:latest
+      volumes:
+        - website:/srv/jekyll
 
     steps:
     - uses: actions/checkout@v2
@@ -45,11 +49,5 @@ jobs:
       with:
         name: website
         path: website
-    - name: Nokogiri dependencies
-      run: sudo apt-get install --no-upgrade libxml2-dev libxslt-dev
-    - name: Install html-proofer
-      env:
-        NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-      run: gem install html-proofer
     - name: Check website
-      run: htmlproofer --empty-alt-ignore website
+      run: /usr/gem/bin/htmlproofer --empty-alt-ignore


### PR DESCRIPTION
This is a follow-up for #40 and reduces the workflow run time from 3 to 2 minutes just because we don't have to install a bunch of stuff.

# Background

I realized the Ubuntu 20.04 runner [comes with a cached container image for `jekyll/builder:latest`](https://github.com/actions/virtual-environments/blob/ubuntu20/20200625.0/images/linux/Ubuntu2004-README.md) and yes, [that image has `html-proofer` preinstalled](https://github.com/envygeeks/jekyll-docker/blob/master/repos/builder/opts.yml#L13). 💪 

So we don't have to:

1. setup Ruby
2. install Nokogiri dependencies using `apt-get`
3. `gem install html-proofer` with a special `NOKOGIRI_USE_SYSTEM_LIBRARIES` env var

and in return for _not_ doing all of this, the workflow **finishes 1 minute earlier!** 🎉 