### PR TITLE
Switch back to OSM tiles

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -10,7 +10,7 @@ const BERLIN_COORDINATES = [13.410, 52.524];
 var map = new Map({
   target: 'mapid',
   layers: [
-    create_tile_layer('https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'),
+    create_tile_layer('https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'),
     roads_layer,
     paths_layer
   ],

--- a/js/index.js
+++ b/js/index.js
@@ -10,7 +10,7 @@ const BERLIN_COORDINATES = [13.410, 52.524];
 var map = new Map({
   target: 'mapid',
   layers: [
-    create_tile_layer('https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png'),
+    create_tile_layer('https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'),
     roads_layer,
     paths_layer
   ],

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -3,6 +3,7 @@ import OSM from 'ol/source/OSM';
 
 export const create_tile_layer = (url) => {
   return new TileLayer({
+    className: 'bw',
     source: new OSM({
       attributions: [
         '&#169; ' +

--- a/stylesheets/berlin.scss
+++ b/stylesheets/berlin.scss
@@ -41,3 +41,7 @@ body > h2 {
 
   @extend %left-margin;
 }
+
+.bw {
+  filter: opacity(50%);
+}


### PR DESCRIPTION
Fixes #54 

Before 65197bb1f802841b7d3e3f9714e33efb5e7c467d, the map was showing the OSM tiles. I found that maps.wikimedia.org was more fitting for this use case but since they're now broken, it was time to go back.