### PR TITLE
Change build to either on push to default branch or pull_request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: build-page
 
-on: [push, pull_request]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
 
 env:
   HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
…but not both.

If we use both, they are using up each other's API quota which is not what we want.